### PR TITLE
POCKET_AUTH not exists. Fixing package.json so it can run on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "start": "./node_modules/webpack-dashboard/bin/webpack-dashboard.js -t 'React-Redux Boilerplate' -- ./node_modules/webpack-dev-server/bin/webpack-dev-server.js",
+    "start": "webpack-dashboard  -- webpack-dev-server --colors --no-info",
     "build": "rm -rf ./build && NODE_ENV=\"production\" ./node_modules/webpack/bin/webpack.js",
     "lint-break-on-errors": "./node_modules/eslint/bin/eslint.js ./source/js ./webpack.config.js -f table --ext .js --ext .jsx",
     "lint": "./node_modules/eslint/bin/eslint.js ./source/js ./webpack.config.js -f table --ext .js --ext .jsx || true",

--- a/source/js/routes.js
+++ b/source/js/routes.js
@@ -19,7 +19,7 @@ export default class Routes extends Component {
       <Router history={ browserHistory }>
         <Route path={ publicPath } component={ App }>
           <IndexRoute component={ Dashboard } />
-          <Route path={ routeCodes.POCKET_AUTH } component={ Dashboard } />
+          <Route path={ routeCodes.DASHBOARD } component={ Dashboard } />
           <Route path={ routeCodes.ABOUT } component={ About } />
 
           <Route path='*' component={ NotFound } />


### PR DESCRIPTION
Simple change in **package.json** that will allow running this boilerplate on Windows (Windows failed on original), Linux and Mac Osx. Also a small fix on routes.js (No **POCKET_AUTH** constant value is defined, it should be **DASHBOARD**).